### PR TITLE
Move includes out of extern "C" block

### DIFF
--- a/timingApiSup/timingApiTypes.h
+++ b/timingApiSup/timingApiTypes.h
@@ -4,12 +4,12 @@
  * The minimal declarations needed to make the timing FIFO API work!
  */
 
+#include <epicsTime.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include <epicsTime.h>
-#include <stdint.h>
 
 /** LCLS-II uses 64bit pulseID's */
 typedef uint64_t TimingPulseId;


### PR DESCRIPTION
This was causing build failures with newer versions of EPICS base because they use templates in epicsTime.h. Templates cannot have C linkage.